### PR TITLE
Fix for enumerating passed devices that are exclusively owned by another process

### DIFF
--- a/apps/common/vJoyInterface.cpp
+++ b/apps/common/vJoyInterface.cpp
@@ -2171,7 +2171,7 @@ HANDLE	GetHandleByIndex(int index)
             LocalFree(functionClassDeviceData);
             SetupDiDestroyDeviceInfoList (hardwareDeviceInfo);
             CloseHandle(HidDevice);
-            return NULL;
+            return INVALID_HANDLE_VALUE;
         }
 
 


### PR DESCRIPTION
I discovered a rather show stopping bug with vJoy just earlier today. I use it in conjunction with DS4Windows, a piece of software that translates input from a DualShock 4 controller to Xinput. One of the features DS4Windows has is the ability to exclusively take control of the DualShock 4 device so that other applications can't access it (which prevents cases of double input). When I used this feature in conjunction with vJoy, all of a sudden vJoy API functions would start to fail.

I discovered that if the DS4 device was enumerated before any of the vJoy devices, any attempt to access properties of those vJoy devices would fail. Worse yet, if the DS4 device was enumerated before all of the vJoy devices, then the entire vJoy API would fall over.

The issue seems to be in vJoyInterface.cpp: when GetHandleByIndex calls CreateFile, if that function fails GetHandleByIndex returns NULL, ceasing any further enumeration of devices in GetDeviceIndexById. However, CreateFile will fail if the device it is attempting to open is exclusively owned by another process. So I changed it to return INVALID_HANDLE_VALUE so that it would continue enumeration. That seems to have fixed things. Hopefully this is the correct fix for this issue.